### PR TITLE
fix: "fixing the jump distance"

### DIFF
--- a/RemoteCode.c
+++ b/RemoteCode.c
@@ -50,16 +50,15 @@ VOID LoopCall( IN PCODE_BUFFER Buffer )
 {
 	Buffer->LoopCall = TRUE;
 }
-
 LONG JumpShort( IN PCODE_BUFFER Buffer, IN LONG Jump )
 {
-	LONG size = 0;
-	size += AddByteToBuffer( Buffer, 0xEB );
-	if (Jump < 2)
-		size += AddByteToBuffer( Buffer, (UCHAR)(0xFE + Jump) );
-	else
-		size += AddByteToBuffer( Buffer, (UCHAR)(Jump - 0x02) );
-	return size;
+    LONG size = 0;
+    size += AddByteToBuffer( Buffer, 0xEB );
+    if (Jump <= 2)
+        size += AddByteToBuffer( Buffer, (UCHAR)(0xFE + Jump) );
+    else
+        size += AddByteToBuffer( Buffer, (UCHAR)(Jump - 0x02) );
+    return size;
 }
 
 LONG Call( IN PCODE_BUFFER Buffer, IN PVOID CallAddress )


### PR DESCRIPTION
substracting two byte from the jump because it might lead to a wrong memory location, it's better to substract two bytes from the jump offset if it is less than or equal to two, rather than only if it is less than two.